### PR TITLE
Include apk upgrade in dockerfile to patch preinstalled packages.

### DIFF
--- a/.changeset/hungry-steaks-exercise.md
+++ b/.changeset/hungry-steaks-exercise.md
@@ -1,0 +1,5 @@
+---
+"nfs-server-alpine": patch
+---
+
+Include apk upgrade in dockerfile to patch preinstalled packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ LABEL BRANCH="master"
 
 COPY Dockerfile README.md /
 
-RUN apk add --no-cache --update --verbose nfs-utils bash iproute2 && \
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache --verbose nfs-utils bash iproute2 && \
     rm -rf /var/cache/apk /tmp /sbin/halt /sbin/poweroff /sbin/reboot && \
     mkdir -p /var/lib/nfs/rpc_pipefs /var/lib/nfs/v4recovery && \
     echo "rpc_pipefs    /var/lib/nfs/rpc_pipefs rpc_pipefs      defaults        0       0" >> /etc/fstab && \


### PR DESCRIPTION
While we pull the latest versions of the optional packages, we don't upgrade the base system packages as part of the build. This adds that to the Dockerfile